### PR TITLE
Feature/store parameters

### DIFF
--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -98,7 +98,7 @@ class Response extends API\Response  {
 	 */
 	public function get_instagram_business_id() {
 
-		$instagram_profiles = $this->get_data()->instagram_profiles;
+		$instagram_profiles = ! empty( $this->get_data()->instagram_profiles ) ? $this->get_data()->instagram_profiles : '';
 
 		if ( empty( $instagram_profiles ) ) {
 			return '';

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -90,6 +90,38 @@ class Response extends API\Response  {
 
 
 	/**
+	 * Gets Instagram Business ID.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @return string
+	 */
+	public function get_instagram_business_id() {
+
+		$instagram_profiles = $this->get_data()->instagram_profiles;
+
+		if ( empty( $instagram_profiles ) ) {
+			return '';
+		}
+
+		return is_array( $instagram_profiles ) ? current( $instagram_profiles ) : $instagram_profiles;
+	}
+
+
+	/**
+	 * Gets the commerce merchant settings ID.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @return string
+	 */
+	public function get_commerce_merchant_settings_id() {
+
+		return ! empty( $this->get_data()->commerce_merchant_settings_id ) ? $this->get_data()->commerce_merchant_settings_id : '';
+	}
+
+
+	/**
 	 * Gets the profiles.
 	 *
 	 * @since 2.0.0

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -140,6 +140,14 @@ class Connection extends Admin\Abstract_Settings_Screen {
 				'label' => __( 'Ad Manager account', 'facebook-for-woocommerce' ),
 				'value' => facebook_for_woocommerce()->get_connection_handler()->get_ad_account_id(),
 			],
+			'instagram-business-id' => [
+				'label' => __( 'Instagram Business ID', 'facebook-for-woocommerce' ),
+				'value' => facebook_for_woocommerce()->get_connection_handler()->get_instagram_business_id(),
+			],
+			'commerce-merchant-settings-id' => [
+				'label' => __( 'Commerce Merchant Settings ID', 'facebook-for-woocommerce' ),
+				'value' => facebook_for_woocommerce()->get_connection_handler()->get_commerce_merchant_settings_id(),
+			],
 		];
 
 		// if the catalog ID is set, update the URL and try to get its name for display

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -68,6 +68,12 @@ class Connection {
 	/** @var string the Commerce manager ID option name */
 	const OPTION_COMMERCE_MANAGER_ID = 'wc_facebook_commerce_manager_id';
 
+	/** @var string Instagram Business ID option name */
+	const OPTION_INSTAGRAM_BUSINESS_ID = 'wc_facebook_instagram_business_id';
+
+	/** @var string the Commerce merchant settings ID option name */
+	const OPTION_COMMERCE_MERCHANT_SETTINGS_ID = 'wc_facebook_commerce_merchant_settings_id';
+
 	/** @var string|null the generated external merchant settings ID */
 	private $external_business_id;
 
@@ -217,6 +223,14 @@ class Connection {
 		if ( $response->get_ad_account_id() ) {
 			$this->update_ad_account_id( sanitize_text_field( $response->get_ad_account_id() ) );
 		}
+
+		if ( $response->get_instagram_business_id() ) {
+			$this->update_instagram_business_id( sanitize_text_field( $response->get_instagram_business_id() ) );
+		}
+
+		if ( $response->get_commerce_merchant_settings_id() ) {
+			$this->update_commerce_merchant_settings_id( sanitize_text_field( $response->get_commerce_merchant_settings_id() ) );
+		}
 	}
 
 
@@ -339,6 +353,8 @@ class Connection {
 		$this->update_system_user_id( '' );
 		$this->update_business_manager_id( '' );
 		$this->update_ad_account_id( '' );
+		$this->update_instagram_business_id( '' );
+		$this->update_commerce_merchant_settings_id( '' );
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
@@ -719,6 +735,32 @@ class Connection {
 
 
 	/**
+	 * Gets Instagram Business ID value.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @return string
+	 */
+	public function get_instagram_business_id() {
+
+		return get_option( self::OPTION_INSTAGRAM_BUSINESS_ID, '' );
+	}
+
+
+	/**
+	 * Gets Commerce merchant settings ID value.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @return string
+	 */
+	public function get_commerce_merchant_settings_id() {
+
+		return get_option( self::OPTION_COMMERCE_MERCHANT_SETTINGS_ID, '' );
+	}
+
+
+	/**
 	 * Gets the proxy URL.
 	 *
 	 * @since 2.0.0
@@ -917,6 +959,32 @@ class Connection {
 	public function update_commerce_manager_id( $id ) {
 
 		update_option( self::OPTION_COMMERCE_MANAGER_ID, $id );
+	}
+
+
+	/**
+	 * Stores the given Instagram Business ID.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param string $id the ID
+	 */
+	public function update_instagram_business_id( $id ) {
+
+		update_option( self::OPTION_INSTAGRAM_BUSINESS_ID, $id );
+	}
+
+
+	/**
+	 * Stores the given Commerce merchant settings ID.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param string $id the ID
+	 */
+	public function update_commerce_merchant_settings_id( $id ) {
+
+		update_option( self::OPTION_COMMERCE_MERCHANT_SETTINGS_ID, $id );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -586,6 +586,7 @@ class Connection {
 			'ads_management',
 			'ads_read',
 			'pages_read_engagement', // this scope is needed to enable order management if using the Commerce feature
+			'instagram_basic',
 		];
 
 		/**
@@ -860,6 +861,8 @@ class Connection {
 				'timezone'             => $this->get_timezone_string(),
 				'currency'             => get_woocommerce_currency(),
 				'business_vertical'    => 'ECOMMERCE',
+				'domain'               => home_url(),
+				'channel'              => 'COMMERCE_OFFSITE',
 			],
 			'business_config' => [
 				'business' => [

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -738,7 +738,7 @@ class Connection {
 	/**
 	 * Gets Instagram Business ID value.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @return string
 	 */
@@ -751,7 +751,7 @@ class Connection {
 	/**
 	 * Gets Commerce merchant settings ID value.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @return string
 	 */
@@ -968,7 +968,7 @@ class Connection {
 	/**
 	 * Stores the given Instagram Business ID.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param string $id the ID
 	 */
@@ -981,7 +981,7 @@ class Connection {
 	/**
 	 * Stores the given Commerce merchant settings ID.
 	 *
-	 * @since 2.1.5
+	 * @since 2.2.1-dev.1
 	 *
 	 * @param string $id the ID
 	 */

--- a/tests/integration/API/FBE/Installation/Read/ResponseTest.php
+++ b/tests/integration/API/FBE/Installation/Read/ResponseTest.php
@@ -13,7 +13,7 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 	/** @var \IntegrationTester */
 	protected $tester;
 
-	protected $data = '{"data":[{"business_manager_id":"1234","ad_account_id":"ad-account","pixel_id":"5678","profiles":["123"],"catalog_id":"456","pages":["123"]}]}';
+	protected $data = '{"data":[{"business_manager_id":"1234","ad_account_id":"ad-account","pixel_id":"5678","profiles":["123"],"catalog_id":"456","commerce_merchant_settings_id":"789","pages":["123"],"instagram_profiles":["345"]}]}';
 
 
 	public function _before() {
@@ -75,6 +75,24 @@ class ResponseTest extends \Codeception\TestCase\WPTestCase {
 		$response = new Response( $this->data );
 
 		$this->assertEquals( '456', $response->get_catalog_id() );
+	}
+
+
+	/** @see Response::get_instagram_business_id() */
+	public function test_get_instagram_business_id() {
+
+		$response = new Response( $this->data );
+
+		$this->assertEquals( '345', $response->get_instagram_business_id() );
+	}
+
+
+	/** @see Response::get_commerce_merchant_settings_id() */
+	public function test_get_commerce_merchant_settings_id() {
+
+		$response = new Response( $this->data );
+
+		$this->assertEquals( '789', $response->get_commerce_merchant_settings_id() );
 	}
 
 

--- a/tests/integration/Handlers/ConnectionTest.php
+++ b/tests/integration/Handlers/ConnectionTest.php
@@ -310,6 +310,26 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Connection::get_instagram_business_id() */
+	public function test_get_instagram_business_id() {
+
+		$instagram_business_id = 'instagram business id';
+		update_option( Connection::OPTION_INSTAGRAM_BUSINESS_ID, $instagram_business_id );
+
+		$this->assertSame( $instagram_business_id, $this->get_connection()->get_instagram_business_id() );
+	}
+
+
+	/** @see Connection::get_commerce_merchant_settings_id() */
+	public function test_get_commerce_merchant_settings_id() {
+
+		$commerce_merchant_settings_id = 'commerce merchant settings id';
+		update_option( Connection::OPTION_COMMERCE_MERCHANT_SETTINGS_ID, $commerce_merchant_settings_id );
+
+		$this->assertSame( $commerce_merchant_settings_id, $this->get_connection()->get_commerce_merchant_settings_id() );
+	}
+
+
 	/** @see Connection::get_proxy_url() */
 	public function test_get_proxy_url() {
 
@@ -599,6 +619,28 @@ class ConnectionTest extends \Codeception\TestCase\WPTestCase {
 		$this->get_connection()->update_commerce_manager_id( $commerce_manager_id );
 
 		$this->assertSame( $commerce_manager_id, get_option( Connection::OPTION_COMMERCE_MANAGER_ID ) );
+	}
+
+
+	/** @see Connection::update_instagram_business_id() */
+	public function test_update_instagram_business_id() {
+
+		$instagram_business_id = 'instagram business id';
+
+		$this->get_connection()->update_instagram_business_id( $instagram_business_id );
+
+		$this->assertSame( $instagram_business_id, $this->get_connection()->get_instagram_business_id() );
+	}
+
+
+	/** @see Connection::update_commerce_merchant_settings_id() */
+	public function test_update_commerce_merchant_settings_id() {
+
+		$commerce_merchant_settings_id = 'commerce merchant settings id';
+
+		$this->get_connection()->update_commerce_merchant_settings_id( $commerce_merchant_settings_id );
+
+		$this->assertSame( $commerce_merchant_settings_id, $this->get_connection()->get_commerce_merchant_settings_id() );
 	}
 
 


### PR DESCRIPTION
- Implement the Commerce merchant settings ID and Instagram Business ID storage
- Add Commerce merchant settings ID and Instagram Business ID values to WC Facebook Settings page
- Update tests
   Tests for Commerce merchant settings ID and Instagram Business ID values.